### PR TITLE
Fix: Error printed when lyrics are fetched sucessfully

### DIFF
--- a/main.py
+++ b/main.py
@@ -57,6 +57,10 @@ try:
             Missing_lyrics = Missing_lyrics + 1
             continue
         try:
+            if (lyrics is  None):
+                logging.info("Lyrics not found for the song: %s", file_path)
+                Missing_lyrics = Missing_lyrics + 1
+                continue
             with open(new_file_path, 'w') as f:
                 f.write(lyrics)
                 Total_lyrics = Total_lyrics + 1

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ def get_lyrics(artist, title, album, duration):
     response = requests.get(url, params=params)
     if response.status_code == 200:
         logging.info("Found Lyrics for the song: %s", title)
-    return response.json()["syncedLyrics"]
+    return response.json()["syncedLyrics"].encoding('utf-8')
 
 def get_song_details(file_path):
     audio = TinyTag.get(file_path)

--- a/main.py
+++ b/main.py
@@ -36,6 +36,7 @@ def collect_flac_files(directory_path):
 
 Found_lyrics = 0
 Missing_lyrics = 0
+Total_lyrics = 0
 print("Starting the lyrics fetching process...")
 print("Writing logs to lyrics_fetch.log")
 


### PR DESCRIPTION
I have traced back to a few different causes to this error

- Undeclared success counter used when success and threw exception. So even if the write was success the catch would trigger and print an unrelated error.
- Sometimes the song was found and the Json downloaded and parsed but wouldn't contain lyrics so it fails while trying to write None to disk. Added a check for this case.
- Other locale characters such as Japanese or Arabic would throw exceptions when writing to disk due to being inexistent on the OS's charset. Fixed by ensuring all text written is encoded in UTF-8.