### PR TITLE
Use UTF-8 encoding, accept path from command line, README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,24 @@
 # Jellyfin-lyrics
 Download lyrics for all of your music
 
-Jellyfin 10.9 added support for lyrics this script helps you to get lyrics effortlessly and make your experience better.Happy Singing!!
+Jellyfin 10.9 added support for lyrics. This script helps you to get lyrics effortlessly and make your experience better. Happy Singing!!
 
 ## Clone repository
 
 ```bash
- git clone https://github.com/sai80082/Jellyfin-lyrics.git
+git clone https://github.com/sai80082/Jellyfin-lyrics.git
 ```
 
 ## Install library tinytag
 
 ```python
-  pip install tinytag
-```
-## Change your directory with your music library directory in python script
-
-Note: I would suggest you give full paht and not relative path
-
-```python
-  directory_path = '/xxxx/xxxx/xxx'
+pip install tinytag
 ```
 
 ## Run python Script
 
 ```python
-  python3 main.py
+python3 main.py full/path/to/directory
 ```
+
+If `python3` doesn't work, try `python` or `py`.

--- a/main.py
+++ b/main.py
@@ -2,11 +2,15 @@ import logging
 from tinytag import TinyTag
 import os
 import requests
+import sys
 
 # Configure logging
 logging.basicConfig(filename='lyrics_fetch.log', level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-directory_path = '/home/serveradmin/media/music'
+directory_path = '.'
+
+if len(sys.argv) > 1:
+    directory_path = sys.argv[1]
 
 def get_lyrics(artist, title, album, duration):
     url = "https://lrclib.net/api/get"
@@ -65,7 +69,7 @@ try:
                 logging.info("Lyrics not found for the song: %s", file_path)
                 Missing_lyrics = Missing_lyrics + 1
                 continue
-            with open(new_file_path, 'w') as f:
+            with open(new_file_path, 'w', encoding="utf-8") as f:
                 f.write(lyrics)
                 Total_lyrics = Total_lyrics + 1
         except Exception as e:


### PR DESCRIPTION
> Use UTF-8 encoding

Python on Windows defaults to ASCII rather than UTF-8, which causes the file to be written improperly when there are non-ASCII characters in the lyrics (such as Japanese characters).

> Accept path from command line

The path should not be hardcoded, but instead retrieved from command line arguments. It should also default to the current working directory (`'.'`) rather than any specific path.

> README fixes

Some slight cleanup in the README.md